### PR TITLE
fix verison replace bug

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -2,6 +2,7 @@ var fs = require( './fs' );
 var path = require( 'path' );
 var crypto = require( 'crypto' );
 var url = require( 'url' );
+var os = require('os');
 
 var UglifyJS = require( 'uglify-js' );
 var CleanCSS = require( 'clean-css' );
@@ -10,6 +11,8 @@ var mkdirp = require( 'mkdirp' );
 
 var util = require( './util' );
 var sysUtil = require( 'util' );
+
+var osPlatform = os.platform().toLocaleLowerCase();
 
 module.exports = function ( grunt, options, mapFiles ) {
 
@@ -68,6 +71,10 @@ module.exports = function ( grunt, options, mapFiles ) {
 
     if ( !isExclude( filepath, options.excludes ) ) {
      minFilepath = path.join( path.dirname( filepath ), path.basename( filepath, '.js') + '_' + signature + '.js' );
+
+        if( osPlatform.indexOf('win32') > -1 ){
+            minFilepath = minFilepath.replace(/\\/g,'/');
+        }
     }
 
     grunt.file.write( path.join( options.dist, minFilepath ), minContent );

--- a/tasks/lib/upload.js
+++ b/tasks/lib/upload.js
@@ -1,7 +1,7 @@
 var fs = require( 'fs' );
 var path = require( 'path' );
 var Emitter = require( 'events' ).EventEmitter;
-
+var os = require('os');
 
 var FTPClient = require( 'ftp' );
 var util = require( './util' );
@@ -10,6 +10,7 @@ var sysUtil = require( 'util' );
 
 var ftpClient = new FTPClient();
 var emitter = new Emitter();
+var osPlatform = os.platform().toLocaleLowerCase();
 
 function isMatch( fileName, patterns ) {
 
@@ -117,6 +118,11 @@ module.exports = function ( grunt, options, done ) {
     var dir = path.dirname( filepath );
 
     dir = path.join( dir, '/' );
+
+    if( osPlatform.indexOf('win32') > -1 ){
+      dir = dir.replace(/\\/g,'/');
+      filepath = filepath.replace(/\\/g,'/');
+    }
 
     ftpClient.mkdir( dir, true, function ( err ) {
 


### PR DESCRIPTION
compress时，生成的plist中，源码文件的路径用的是“\”因此导致版本替换时匹配不到
所以这次的提交生成的plist中文件路径用的“/”，然后版本号就能正确的替换。windows下运行正常，inc和dict版本号都进行了正确的替换
linux麻烦测试下~
